### PR TITLE
Fix loading from web storage not working

### DIFF
--- a/src/storage/ReactiveWebStorage.js
+++ b/src/storage/ReactiveWebStorage.js
@@ -40,7 +40,7 @@ export class ReactiveWebStorage {
    */
   obtainReactiveStorageAdapterKey(key) {
     const keyElements = key.split('-')
-    return keyElements[keyElements - 1]
+    return keyElements[keyElements.length - 1]
   }
 
   get reactiveStorageAdapter() {


### PR DESCRIPTION
Currently, loading from web storage doesn't work. The reason is that `obtainReactiveStorageAdapterKey` always returns `undefined` due to a bad array index access (`keyElements[keyElements - 1]` instead of `keyElements[keyElements.length - 1]`). This fixes it.